### PR TITLE
fix: make sure lazygit is closed when a file is opened behind it

### DIFF
--- a/integration-tests/cypress/e2e/lazygit.cy.ts
+++ b/integration-tests/cypress/e2e/lazygit.cy.ts
@@ -56,6 +56,21 @@ describe("testing", () => {
     })
   })
 
+  it("hides lazygit when clicked outside of the floating window", () => {
+    cy.visit("/")
+
+    cy.startNeovim({ filename: "fakegitrepo/file.txt" }).then(() => {
+      cy.contains("fake-git-repository-file-contents-71f64aabd056")
+      initializeGitRepositoryInDirectory()
+
+      cy.typeIntoTerminal("{rightarrow}")
+      cy.contains(lazygit.donateMessage)
+
+      cy.contains("fake-git-repository-file-contents-71f64aabd056").click()
+      cy.contains(lazygit.donateMessage).should("not.exist")
+    })
+  })
+
   it("can open lazygit after COMMIT_EDITMSG is closed", () => {
     cy.visit("/")
 


### PR DESCRIPTION
sometimes when editing a commit message, the terminal is left open. In    
this case, toggling tsugit should close the terminal so that only one can 
be open at a time.                                                        
