### PR TITLE
ci: downgrade runner OS to ubuntu-22.04 for linkspector

### DIFF
--- a/.github/workflows/linkspector.yml
+++ b/.github/workflows/linkspector.yml
@@ -3,7 +3,9 @@ on: [pull_request]
 jobs:
   check-links:
     name: runner / linkspector
-    runs-on: ubuntu-latest
+    # Temporarily work around this issue by downgrading the runner OS
+    # https://github.com/UmbrellaDocs/action-linkspector/issues/32
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4.2.2
       - name: Run linkspector


### PR DESCRIPTION
https://github.com/UmbrellaDocs/action-linkspector/issues/32