### PR TITLE
fix: snacks not closing anymore due to new changes

### DIFF
--- a/lua/tsugit.lua
+++ b/lua/tsugit.lua
@@ -146,6 +146,13 @@ function M.toggle(args, options)
       end,
     })
 
+    lazygit:on("TermClose", function()
+      lazygit:close({ buf = true })
+      if vim.api.nvim_buf_is_valid(lazygit.buf) then
+        vim.api.nvim_buf_delete(lazygit.buf, { force = true })
+      end
+    end)
+
     vim.api.nvim_create_autocmd({ "WinLeave" }, {
       buffer = lazygit.buf,
       callback = function()


### PR DESCRIPTION
It would leave a message saying "Process exited 0" and the buffer would still be open. Work around this change so that lazygit can be restarted like it used to be before.