### PR TITLE
Bump lazygit version in ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           # https://github.com/jesseduffield/lazygit?tab=readme-ov-file#ubuntu
           # https://api.github.com/repos/jesseduffield/lazygit/releases/latest
-          LAZYGIT_VERSION="https://github.com/jesseduffield/lazygit/releases/download/v0.47.1/lazygit_0.47.1_Linux_x86_64.tar.gz"
+          LAZYGIT_VERSION="https://github.com/jesseduffield/lazygit/releases/download/v0.49.0/lazygit_0.49.0_Linux_x86_64.tar.gz"
           curl -Lo lazygit.tar.gz $LAZYGIT_VERSION
           tar xf lazygit.tar.gz lazygit
           sudo install lazygit -D -t /usr/local/bin/

--- a/integration-tests/cypress/e2e/lazygit.cy.ts
+++ b/integration-tests/cypress/e2e/lazygit.cy.ts
@@ -102,15 +102,16 @@ describe("testing", () => {
       cy.typeIntoTerminal("{rightarrow}")
       cy.contains("main")
 
-      // TODO tui-sandbox should have a human readable way to match the text on the screen
-      //
-      // for now just match on the symbol before the file since the test
-      // environment is well controlled anyway
-      cy.contains("??").should(
+      // the file tree root item (📁 /) should be selected
+      cy.contains("/").should(
         "have.css",
         "background-color",
         colors.selectedItem,
       )
+
+      // select the first file in the file tree (move the selection away from
+      // the root of the tree)
+      cy.typeIntoTerminal("j")
 
       // stage all files
       cy.typeIntoTerminal("a")
@@ -156,6 +157,17 @@ describe("testing", () => {
 
       cy.typeIntoTerminal("{rightarrow}")
       cy.contains("Donate")
+
+      // the file tree root item (📁 /) should be selected
+      cy.contains("/").should(
+        "have.css",
+        "background-color",
+        colors.selectedItem,
+      )
+
+      // select the first file in the file tree (move the selection away from
+      // the root of the tree)
+      cy.typeIntoTerminal("j")
 
       cy.contains("??").should(
         "have.css",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "prettier-plugin-organize-imports": "4.1.0",
     "prettier-plugin-packagejson": "2.5.10"
   },
-  "packageManager": "pnpm@10.7.1+sha512.2d92c86b7928dc8284f53494fb4201f983da65f0fb4f0d40baafa5cf628fa31dae3e5968f12466f17df7e97310e30f343a648baea1b9b350685dafafffdf5808",
+  "packageManager": "pnpm@10.8.1+sha512.c50088ba998c67b8ca8c99df8a5e02fd2ae2e2b29aaf238feaa9e124248d3f48f9fb6db2424949ff901cffbb5e0f0cc1ad6aedb602cd29450751d11c35023677",
   "pnpm": {
     "onlyBuiltDependencies": [
       "core-js",


### PR DESCRIPTION
# test: bump ci lazygit version from 0.47.1 to 0.49.0

Needed to adapt the e2e tests a bit, but nothing big


# chore: bump pnpm from 10.7.1 to 10.8.1

