### PR TITLE
fix: sometimes focusing on the wrong split after closing lazygit

### DIFF
--- a/integration-tests/cypress/e2e/lazygit.cy.ts
+++ b/integration-tests/cypress/e2e/lazygit.cy.ts
@@ -13,12 +13,14 @@ const lazygit = {
   donateMessage: "Donate",
 } as const
 
+const fakeGitRepoFileText = "fake-git-repository-file-contents-71f64aabd056"
+
 describe("testing", () => {
   it("can toggle lazygit on/off", () => {
     cy.visit("/")
     cy.startNeovim({ filename: "fakegitrepo/file.txt" }).then(() => {
       // wait until text on the start screen is visible
-      cy.contains("fake-git-repository-file-contents-71f64aabd056")
+      cy.contains(fakeGitRepoFileText)
       initializeGitRepositoryInDirectory()
 
       cy.typeIntoTerminal("{rightarrow}")
@@ -61,13 +63,13 @@ describe("testing", () => {
     cy.visit("/")
 
     cy.startNeovim({ filename: "fakegitrepo/file.txt" }).then(() => {
-      cy.contains("fake-git-repository-file-contents-71f64aabd056")
+      cy.contains(fakeGitRepoFileText)
       initializeGitRepositoryInDirectory()
 
       cy.typeIntoTerminal("{rightarrow}")
       cy.contains(lazygit.donateMessage)
 
-      cy.contains("fake-git-repository-file-contents-71f64aabd056").click()
+      cy.contains(fakeGitRepoFileText).click()
       cy.contains(lazygit.donateMessage).should("not.exist")
     })
   })
@@ -76,7 +78,7 @@ describe("testing", () => {
     cy.visit("/")
 
     cy.startNeovim({ filename: "fakegitrepo/file.txt" }).then((nvim) => {
-      cy.contains("fake-git-repository-file-contents-71f64aabd056")
+      cy.contains(fakeGitRepoFileText)
       initializeGitRepositoryInDirectory()
       nvim.runExCommand({ command: "e %:h/.git/COMMIT_EDITMSG" })
       cy.typeIntoTerminal("itest commit message{esc}", { delay: 0 })
@@ -96,7 +98,7 @@ describe("testing", () => {
         VISUAL: "nvim",
       },
     }).then((nvim) => {
-      cy.contains("fake-git-repository-file-contents-71f64aabd056")
+      cy.contains(fakeGitRepoFileText)
       initializeGitRepositoryInDirectory()
 
       cy.typeIntoTerminal("{rightarrow}")
@@ -146,7 +148,7 @@ describe("testing", () => {
       },
     }).then((nvim) => {
       initializeGitRepositoryInDirectory()
-      cy.contains("fake-git-repository-file-contents-71f64aabd056")
+      cy.contains(fakeGitRepoFileText)
       nvim.runBlockingShellCommand({
         command:
           "cd fakegitrepo && git add file.txt && git commit -a -m 'initial commit'",
@@ -182,9 +184,7 @@ describe("testing", () => {
       cy.contains("Donate").should("not.exist")
 
       // the file should have been opened in neovim
-      cy.contains("fake-git-repository-file-contents-71f64aabd056").should(
-        "not.exist",
-      )
+      cy.contains(fakeGitRepoFileText).should("not.exist")
       cy.contains("file2-contents")
     })
   })
@@ -200,7 +200,7 @@ describe("testing", () => {
       },
     }).then((nvim) => {
       initializeGitRepositoryInDirectory()
-      cy.contains("fake-git-repository-file-contents-71f64aabd056")
+      cy.contains(fakeGitRepoFileText)
       nvim.runBlockingShellCommand({
         command:
           "cd fakegitrepo && git add file.txt && git commit -a -m 'initial commit'",
@@ -236,7 +236,7 @@ describe("testing", () => {
     cy.visit("/")
     cy.startNeovim({ filename: "fakegitrepo/file.txt" }).then((_nvim) => {
       // wait until text on the start screen is visible
-      cy.contains("fake-git-repository-file-contents-71f64aabd056")
+      cy.contains(fakeGitRepoFileText)
       initializeGitRepositoryInDirectory()
 
       cy.typeIntoTerminal("{rightarrow}")
@@ -276,7 +276,7 @@ describe("toggle_for_file", () => {
     cy.visit("/")
     cy.startNeovim({ filename: "fakegitrepo/file.txt" }).then((nvim) => {
       // wait until text on the start screen is visible
-      cy.contains("fake-git-repository-file-contents-71f64aabd056")
+      cy.contains(fakeGitRepoFileText)
       initializeGitRepositoryInDirectory()
 
       // create a commit for the root repo that includes all files in this mini
@@ -313,7 +313,7 @@ describe("toggle_for_file", () => {
       // verify that the commit message for that file only is visible when
       // toggle_for_file is used
       nvim.runExCommand({ command: "edit %:h/file.txt" })
-      cy.contains("fake-git-repository-file-contents-71f64aabd056")
+      cy.contains(fakeGitRepoFileText)
 
       nvim.runLuaCode({
         luaCode: `require('tsugit').toggle_for_file()`,

--- a/integration-tests/cypress/e2e/test-utils.ts
+++ b/integration-tests/cypress/e2e/test-utils.ts
@@ -1,0 +1,23 @@
+import type { RunLuaCodeOutput } from "@tui-sandbox/library/src/server/types"
+import type { MyTestDirectoryFile } from "MyTestDirectory"
+
+export function initializeGitRepositoryInDirectory(
+  relativePath: MyTestDirectoryFile = "fakegitrepo",
+): void {
+  cy.nvim_runBlockingShellCommand({
+    command: `git init`,
+    cwdRelative: relativePath,
+  }).and((result) => {
+    assert(result.type === "success", "Failed to initialize git repository")
+  })
+}
+
+export function assertCurrentBufferName(
+  name: MyTestDirectoryFile,
+): Cypress.Chainable<RunLuaCodeOutput> {
+  return cy
+    .nvim_runLuaCode({ luaCode: `return vim.api.nvim_buf_get_name(0)` })
+    .then((result) => {
+      expect(result.value).to.match(new RegExp(name))
+    })
+}

--- a/lua/tsugit.lua
+++ b/lua/tsugit.lua
@@ -141,6 +141,7 @@ function M.toggle(args, options)
 
   assert(lazygit, "tsugit.nvim: failed to create lazygit terminal")
   vim.api.nvim_buf_set_var(lazygit.buf, "minicursorword_disable", true)
+  local previous_buffer = vim.api.nvim_get_current_buf()
   lazygit:show()
 
   if created then
@@ -158,6 +159,11 @@ function M.toggle(args, options)
       -- the terminal application has exited.
       if vim.api.nvim_buf_is_valid(lazygit.buf) then
         vim.api.nvim_buf_delete(lazygit.buf, { force = true })
+
+        -- focus the previous_buffer after closing lazygit
+        if vim.api.nvim_buf_is_valid(previous_buffer) then
+          vim.api.set_current_buf(previous_buffer)
+        end
       end
 
       -- warm up the next instance


### PR DESCRIPTION
# fix: sometimes focusing on the wrong split after closing lazygit

# test: extract and reuse fakeGitRepoFileText

