### PR TITLE
ci: bump lazygit version from 0.49.0 to 0.50.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           # https://github.com/jesseduffield/lazygit?tab=readme-ov-file#ubuntu
           # https://api.github.com/repos/jesseduffield/lazygit/releases/latest
-          LAZYGIT_VERSION="https://github.com/jesseduffield/lazygit/releases/download/v0.49.0/lazygit_0.49.0_Linux_x86_64.tar.gz"
+          LAZYGIT_VERSION="https://github.com/jesseduffield/lazygit/releases/download/v0.50.0/lazygit_0.50.0_Linux_x86_64.tar.gz"
           curl -Lo lazygit.tar.gz $LAZYGIT_VERSION
           tar xf lazygit.tar.gz lazygit
           sudo install lazygit -D -t /usr/local/bin/


### PR DESCRIPTION
https://github.com/jesseduffield/lazygit/releases/tag/v0.50.0