### PR TITLE
fix: closing lazygit when any neovim `TermClose` event fires

### DIFF
--- a/lua/tsugit.lua
+++ b/lua/tsugit.lua
@@ -214,7 +214,9 @@ function M.toggle(args, options)
       if newLazyGit then
         newLazyGit:hide()
       end
-    end)
+    end, {
+      buffer = lazygit.buf,
+    })
 
     lazygit:on("WinLeave", function()
       lazygit:hide()


### PR DESCRIPTION
**Issue:**

After starting lazygit, if you start an unrelated terminal in Neovim and then close it, the lazygit is also closed. This is because the `TermClose` event is currently triggered for all terminal buffers, not just the one running lazygit.

I ran into this when using https://github.com/mikavilpas/yazi.nvim, but didn't notice it happens until now.

**Solution:**

Only close lazygit when the terminal buffer that lazygit is running in is closed.