### PR TITLE
fix: plugin cache miss for some existing lazygits

### DIFF
--- a/lua/tsugit/cache.lua
+++ b/lua/tsugit/cache.lua
@@ -1,0 +1,33 @@
+local M = {}
+
+--- issue: The snacks terminal seems to have some issue that causes duplicate
+--- lazygits to be opened
+---
+--- solution: Provides a cache for the lazygits that are known to tsugit. We
+--- can use this to detect if a lazygit has already been opened, and avoiding
+--- opening a new one if it has. This essentially duplicates the snacks
+--- terminal's cache.
+---@type table<string, snacks.win>
+M.lazygit_cache = {
+  -- `v` means weak values, which allows garbage collecting them when they have
+  -- no other references, see :help lua-weaktable
+  --
+  -- `k` is the same thing but for keys
+  __mode = "kv",
+}
+
+function M.add_lazygit(key, lazygit)
+  assert(
+    not M.lazygit_cache[key],
+    "tsugit.nvim: lazygit already exists for key: " .. key
+  )
+  M.lazygit_cache[key] = lazygit
+  lazygit.tsugit_key = key
+end
+
+function M.delete_lazygit(key)
+  assert(M.lazygit_cache[key])
+  M.lazygit_cache[key] = nil
+end
+
+return M

--- a/lua/tsugit/keymaps.lua
+++ b/lua/tsugit/keymaps.lua
@@ -21,6 +21,8 @@ function M.create_keymaps(config, lazygit)
       vim.o.lazyredraw = true
       pcall(function()
         lazygit:close({ buf = true })
+
+        require("tsugit.cache").delete_lazygit(lazygit["tsugit_key"])
       end)
       vim.o.lazyredraw = false
     end, { buffer = lazygit.buf })


### PR DESCRIPTION
Two possible problems were fixed:

- after force_quitting lazygit, the cache was not cleared, which sometimes caused problems when trying to open a new lazygit in the same directory
- sometimes the lazygit cache was bypassed because snacks reported it being `closed`, but it was actually still open.

I added strict assertions to ensure that the cache is always respected.

Also refactored the cache into its own module, and added some accessors.