### PR TITLE
Important fixes for force_quit

### DIFF
--- a/lua/tsugit.lua
+++ b/lua/tsugit.lua
@@ -166,7 +166,9 @@ function M.toggle(args, options)
 
             -- warm up the next instance
             local newLazyGit = M.toggle(event, {
-              tries_remaining = (options.tries_remaining or 0) - 1,
+              tries_remaining = options.tries_remaining
+                  and options.tries_remaining - 1
+                or 1,
               term_opts = options.term_opts,
             })
             if newLazyGit then

--- a/lua/tsugit.lua
+++ b/lua/tsugit.lua
@@ -194,7 +194,7 @@ function M.toggle(args, options)
       -- warm up the next instance
       local newLazyGit = M.toggle(args, {
         tries_remaining = (options.tries_remaining or 0) - 1,
-        term_opts = {},
+        term_opts = options.term_opts,
       })
       if newLazyGit then
         newLazyGit:hide()

--- a/lua/tsugit/cache.lua
+++ b/lua/tsugit/cache.lua
@@ -16,6 +16,8 @@ M.lazygit_cache = {
   __mode = "kv",
 }
 
+---@param key string
+---@param lazygit unknown
 function M.add_lazygit(key, lazygit)
   assert(
     not M.lazygit_cache[key],
@@ -25,8 +27,8 @@ function M.add_lazygit(key, lazygit)
   lazygit.tsugit_key = key
 end
 
+---@param key string
 function M.delete_lazygit(key)
-  assert(M.lazygit_cache[key])
   M.lazygit_cache[key] = nil
 end
 

--- a/lua/tsugit/cache.lua
+++ b/lua/tsugit/cache.lua
@@ -7,7 +7,7 @@ local M = {}
 --- can use this to detect if a lazygit has already been opened, and avoiding
 --- opening a new one if it has. This essentially duplicates the snacks
 --- terminal's cache.
----@type table<string, snacks.win>
+---@type table<string, snacks.terminal>
 M.lazygit_cache = {
   -- `v` means weak values, which allows garbage collecting them when they have
   -- no other references, see :help lua-weaktable

--- a/lua/tsugit/keymaps.lua
+++ b/lua/tsugit/keymaps.lua
@@ -20,8 +20,17 @@ function M.create_keymaps(config, lazygit)
     vim.keymap.set({ "t" }, config.keys.force_quit, function()
       vim.o.lazyredraw = true
       pcall(function()
+        if config.debug then
+          require("tsugit.debug").add_debug_message(
+            "tsugit.nvim: force quitting lazygit"
+          )
+        end
         lazygit:close({ buf = true })
 
+        assert(
+          lazygit["tsugit_key"],
+          "tsugit.nvim: missing tsugit_key in lazygit"
+        )
         require("tsugit.cache").delete_lazygit(lazygit["tsugit_key"])
       end)
       vim.o.lazyredraw = false

--- a/lua/tsugit/snacks.lua
+++ b/lua/tsugit/snacks.lua
@@ -3,8 +3,9 @@ local M = {}
 ---@param args string[] | nil # arguments to pass to lazygit
 ---@param options tsugit.CallOptions
 ---@param cwd_absolute string
----@return snacks.win, boolean
-function M.maybe_create_lazygit(args, options, cwd_absolute)
+---@param on_buf fun(buf: number)
+---@return snacks.terminal, boolean
+function M.maybe_create_lazygit(args, options, cwd_absolute, on_buf)
   local terminal = require("snacks.terminal")
   ---@type snacks.terminal.Opts
   local default_opts = {
@@ -16,6 +17,9 @@ function M.maybe_create_lazygit(args, options, cwd_absolute)
       width = 0.95,
       height = 0.97,
       style = "minimal",
+      on_buf = function(self)
+        on_buf(self.buf)
+      end,
     },
   }
 
@@ -32,6 +36,7 @@ function M.maybe_create_lazygit(args, options, cwd_absolute)
 
   assert(lazygit, "tsugit.nvim: failed to create lazygit terminal")
 
+  ---@cast lazygit snacks.terminal
   return lazygit, created or false
 end
 


### PR DESCRIPTION
# fix: not automatically restarting lazygit after `force_quit`

# fix: displaying an empty lazygit after `force_quit`

**Issue:**

When lazygit is force-quit (e.g. by pressing `q`), toggling it back on
displays an empty lazygit pane.

Because of a race condition, the current way of reacting to the
`TermClose` event (i.e. when lazygit is closed) can sometimes be left
undone, which results in an invalid cache state.

**Solution:**

Wait until the buffer is created before setting up the `TermClose` event
handler. This ensures that the event handler is always set up, and we
can do cleanup properly.

Add tests to catch this issue in the future.

# fix: forgetting term_opts in warming up the next instance

# refactor: add explicit parameters to cache.lua

# refactor: add some debug messages to keymaps.lua

