### PR TITLE
chore: remove unnecessary references to vite in the config

### DIFF
--- a/integration-tests/eslint.config.mjs
+++ b/integration-tests/eslint.config.mjs
@@ -5,7 +5,6 @@ import * as typescriptEslint from "typescript-eslint"
 export default typescriptEslint.config(
   {
     ignores: [
-      "**/vite.config.js",
       "**/cypress.config.ts",
       "**/test-environment/",
       "eslint.config.mjs",

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -4,11 +4,10 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "tsc && vite build",
+    "build": "tsc",
     "cy:open": "cypress open --e2e --browser=electron",
     "cy:run": "concurrently --success command-cypress --kill-others --names 'app,cypress' --prefix-colors 'blue,yellow' 'pnpm tui start' 'wait-on --timeout 60000 http://127.0.0.1:3000 && npx cypress run'",
     "dev": "concurrently --kill-others --names 'app,cypress' --prefix-colors 'blue,yellow' 'pnpm tui start' 'pnpm cy:open'",
-    "dev:client": "vite",
     "eslint": "eslint --max-warnings=0 ."
   },
   "dependencies": {


### PR DESCRIPTION
Vite is not actually part of the project in any way. It's a remnant of copying the base of the project from another one that used vite.