### PR TITLE
test: stop closing the introduction popup manually

### DIFF
--- a/integration-tests/cypress/e2e/lazygit.cy.ts
+++ b/integration-tests/cypress/e2e/lazygit.cy.ts
@@ -28,8 +28,6 @@ describe("testing", () => {
       initializeGitRepositoryInDirectory()
 
       cy.typeIntoTerminal("{rightarrow}")
-      // close any introduction popup. TODO this should be done automatically
-      cy.typeIntoTerminal("{esc}")
 
       // wait until lazygit has initialized and the main branch name is visible
       cy.contains("main")
@@ -322,8 +320,6 @@ describe("testing", () => {
       initializeGitRepositoryInDirectory()
 
       cy.typeIntoTerminal("{rightarrow}")
-      // close any introduction popup. TODO this should be done automatically
-      cy.typeIntoTerminal("{esc}")
 
       // wait until lazygit has initialized and the main branch name is visible
       cy.contains("main")


### PR DESCRIPTION
This is now handled with `disableStartupPopups: true` in the lazygit config instead