### PR TITLE
Linkspector

### DIFF
--- a/.linkspector.yml
+++ b/.linkspector.yml
@@ -4,6 +4,6 @@ useGitIgnore: true
 ignorePatterns:
   # these seem to fail due to timeouts anyway
   # https://github.com/UmbrellaDocs/linkspector/issues/5
-  - pattern: "https://github.com/mikavilpas/yazi.nvim/assets/.*"
+  - pattern: "https://github.com/mikavilpas/tsugit.nvim/assets/.*"
   # when creating a new release, the link to the compare page is not yet valid
-  - pattern: "https://github.com/mikavilpas/yazi.nvim/compare/\\w+"
+  - pattern: "https://github.com/mikavilpas/tsugit.nvim/compare/\\w+"


### PR DESCRIPTION
# ci: fix linkspector referring to another project

It's likely a copy paste error

# ci: fix linkspector failing on missing documentation dir