### PR TITLE
ci: bump lazygit version from 0.54.2 to 0.55.0

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,2 +1,5 @@
 [tools]
-lazygit = "0.54.2"
+"github:jesseduffield/lazygit" = "0.55.0"
+
+[settings]
+experimental = true


### PR DESCRIPTION
# ci: bump lazygit version from 0.54.2 to 0.55.0

Also use the experimental github backend because the old one does not
see the latest version yet.