### PR TITLE
chore(mise): disable node tool

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -3,3 +3,4 @@
 
 [settings]
 experimental = true
+idiomatic_version_file_enable_tools = []


### PR DESCRIPTION
It's already managed by pnpm in ci. Locally devs can enable it if they want.