### PR TITLE
ci: remove dependabot-prs job as unused

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,21 +64,3 @@ jobs:
           path: integration-tests/cypress/screenshots
           if-no-files-found: ignore # 'warn' or 'error' are also available, defaults to `warn`
           overwrite: true # defaults to `false`, set to `true` to overwrite existing artifacts with the same name
-
-  automerge:
-    needs: build
-    name: Automerge Dependabot PRs
-    runs-on: ubuntu-24.04
-    permissions:
-      # NOTE: no special token needs to be generated if these permissions are
-      # used. However, "Workflow permissions > Allow GitHub Actions to create
-      # and approve pull requests" needs to be enabled under
-      # github.com/user/repo/settings/actions
-      # https://github.com/fastify/github-action-merge-dependabot/issues/359
-      pull-requests: write
-      contents: write
-    steps:
-      - uses: fastify/github-action-merge-dependabot@e820d631adb1d8ab16c3b93e5afe713450884a4a # v3.11.1
-        with:
-          # https://github.com/fastify/github-action-merge-dependabot?tab=readme-ov-file
-          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Since 3887fdd96bb1, renovate is used instead of dependabot for dependency updates. The dependabot-prs job is no longer needed.