### PR TITLE
feat: allow toggle_for_file to accept additional lazygit args

### DIFF
--- a/integration-tests/MyTestDirectory.ts
+++ b/integration-tests/MyTestDirectory.ts
@@ -87,8 +87,8 @@ export const MyTestDirectorySchema = z.object({
       name: z.literal("config-modifications/"),
       type: z.literal("directory"),
       contents: z.object({
-        "use_light_neovim_colorscheme.lua": z.object({
-          name: z.literal("use_light_neovim_colorscheme.lua"),
+        "map_key_to_start_lazygit_in_normal_screen_mode.lua": z.object({
+          name: z.literal("map_key_to_start_lazygit_in_normal_screen_mode.lua"),
           type: z.literal("file"),
         }),
       }),
@@ -205,7 +205,7 @@ export const testDirectoryFiles = z.enum([
   ".config/nvim_formatting/prepare.lua",
   ".config/nvim_formatting",
   ".config",
-  "config-modifications/use_light_neovim_colorscheme.lua",
+  "config-modifications/map_key_to_start_lazygit_in_normal_screen_mode.lua",
   "config-modifications",
   "dir with spaces/file1.txt",
   "dir with spaces/file2.txt",

--- a/integration-tests/cypress/e2e/lazygit.cy.ts
+++ b/integration-tests/cypress/e2e/lazygit.cy.ts
@@ -285,6 +285,29 @@ describe("testing", () => {
     })
   })
 
+  it("can start toggle_for_file in a different screen mode", () => {
+    cy.visit("/")
+
+    cy.startNeovim({
+      filename: "fakegitrepo/file.txt",
+      startupScriptModifications: [
+        "map_key_to_start_lazygit_in_normal_screen_mode.lua",
+      ],
+    }).then((nvim) => {
+      initializeGitRepositoryInDirectory()
+      cy.contains(fakeGitRepoFileText)
+      nvim.runBlockingShellCommand({
+        command: "git add file.txt && git commit -a -m 'initial commit'",
+        cwdRelative: "fakegitrepo",
+      })
+
+      cy.typeIntoTerminal(" lF")
+
+      // the normal screen mode should have been applied
+      cy.contains("Worktrees")
+    })
+  })
+
   it("can force_quit lazygit", () => {
     cy.visit("/")
     cy.startNeovim({ filename: "fakegitrepo/file.txt" }).then((_nvim) => {

--- a/integration-tests/test-environment/config-modifications/map_key_to_start_lazygit_in_normal_screen_mode.lua
+++ b/integration-tests/test-environment/config-modifications/map_key_to_start_lazygit_in_normal_screen_mode.lua
@@ -1,0 +1,9 @@
+vim.keymap.set("n", "<leader>lF", function()
+  local current_file_path = vim.api.nvim_buf_get_name(0)
+
+  require("tsugit").toggle_for_file(
+    current_file_path,
+    {},
+    { "--screen-mode", "normal" }
+  )
+end)

--- a/integration-tests/test-environment/config-modifications/use_light_neovim_colorscheme.lua
+++ b/integration-tests/test-environment/config-modifications/use_light_neovim_colorscheme.lua
@@ -1,3 +1,0 @@
--- Catppuccin defines a custom command to correctly switch the colorscheme
--- https://github.com/catppuccin/nvim
-vim.cmd("Catppuccin latte")

--- a/lua/tsugit.lua
+++ b/lua/tsugit.lua
@@ -257,7 +257,8 @@ end
 --- Open lazygit for the current file path
 ---@param path? string # the file path to open lazygit in. If not given, uses the current buffer's file path.
 ---@param options? tsugit.CallOptions | {}
-function M.toggle_for_file(path, options)
+---@param additional_args? string[] # additional arguments to pass to lazygit
+function M.toggle_for_file(path, options, additional_args)
   path = path or vim.fn.expand("%:p")
   if not path then
     -- might happen if the current buffer is not a file (rare)
@@ -268,8 +269,9 @@ function M.toggle_for_file(path, options)
   -- don't warm up the next lazygit for a single file path to save some resources
   options = options or {}
   options.tries_remaining = 1 -- just one try
+  local args = vim.list_extend({ "--filter", path }, additional_args or {})
 
-  return M.toggle({ "--filter", path }, options)
+  return M.toggle(args, options)
 end
 
 return M


### PR DESCRIPTION
I can use this to start lazygit in normal screen mode. By default, lazygit opens in a half-half screen mode which makes the diff part of the screen too small to be useful.