### PR TITLE
feat: ignore long git trailers in prettier prose wrap

### DIFF
--- a/integration-tests/cypress/e2e/lazygit.cy.ts
+++ b/integration-tests/cypress/e2e/lazygit.cy.ts
@@ -619,4 +619,171 @@ describe("conform integration for commit message formatting", () => {
         .should("equal", [longSubject, " ", "- list", ""].join("\n"))
     })
   })
+
+  it("preserves a long git trailer on a single line even when it exceeds the wrap width", () => {
+    // With --print-width=72 --prose-wrap=always, prettier would split a
+    // "Fixes: <long-url>" line at the space after "Fixes:", breaking
+    // GitHub's closing-keyword linking. The conform integration extracts
+    // the trailer block before prettier runs and re-appends it intact.
+    const trailerUrl =
+      "https://example.com/very-long-organization-name/some-repo/issues/12345-long-slug"
+    const trailerLine = `Fixes: ${trailerUrl}`
+    assert(trailerLine.length > 72)
+
+    cy.visit("/")
+
+    cy.startNeovim({
+      filename: "fakegitrepo/file.txt",
+      NVIM_APPNAME: "nvim_formatting",
+    }).then((nvim) => {
+      cy.contains(fakeGitRepoFileText)
+      initializeGitRepositoryInDirectory()
+      nvim.runBlockingShellCommand({
+        command: `git add .`,
+        cwdRelative: "fakegitrepo",
+      })
+      cy.typeIntoTerminal("{rightarrow}")
+      cy.contains("main")
+
+      cy.typeIntoTerminal("C") // commit
+      nvim.waitForLuaCode({
+        luaAssertion: `return vim.api.nvim_buf_get_name(0) == vim.fn.expand('%:h') .. '/.git/COMMIT_EDITMSG'`,
+      })
+      cy.contains("# Please enter the commit message for your changes.")
+
+      // Set up: subject, blank, body, blank, trailer — inserted via
+      // nvim_buf_set_lines so neovim's textwidth=72 auto-wrap doesn't split
+      // the long trailer line as we construct the test message. We want to
+      // test the prettier-wrap protection, not the typing-path wrap.
+      nvim.runLuaCode({
+        luaCode: `vim.api.nvim_buf_set_lines(0, 0, 0, false, { "test subject", "", "body text", "", ${JSON.stringify(trailerLine)} })`,
+      })
+      cy.typeIntoTerminal(":w{enter}")
+
+      waitForFormattingToHaveCompleted(nvim)
+
+      nvim.runExCommand({ command: `1,6yank` })
+      nvim.clipboard
+        .system()
+        .should(
+          "equal",
+          ["test subject", "", "body text", "", trailerLine, "", ""].join("\n"),
+        )
+    })
+  })
+
+  it("preserves a trailer block of multiple consecutive trailers", () => {
+    // Git trailer blocks can contain multiple lines (Fixes:, Signed-off-by:,
+    // Co-authored-by:, etc.). The whole last paragraph should be protected
+    // as a unit — every line must match the trailer pattern.
+    const fixesLine =
+      "Fixes: https://example.com/very-long-organization-name/some-repo/issues/12345-long-slug"
+    const coauthorLine =
+      "Co-authored-by: Alice Example <alice@very-long-organization-name.example.com>"
+    assert(fixesLine.length > 72)
+    assert(coauthorLine.length > 72)
+
+    cy.visit("/")
+
+    cy.startNeovim({
+      filename: "fakegitrepo/file.txt",
+      NVIM_APPNAME: "nvim_formatting",
+    }).then((nvim) => {
+      cy.contains(fakeGitRepoFileText)
+      initializeGitRepositoryInDirectory()
+      nvim.runBlockingShellCommand({
+        command: `git add .`,
+        cwdRelative: "fakegitrepo",
+      })
+      cy.typeIntoTerminal("{rightarrow}")
+      cy.contains("main")
+
+      cy.typeIntoTerminal("C") // commit
+      nvim.waitForLuaCode({
+        luaAssertion: `return vim.api.nvim_buf_get_name(0) == vim.fn.expand('%:h') .. '/.git/COMMIT_EDITMSG'`,
+      })
+      cy.contains("# Please enter the commit message for your changes.")
+
+      nvim.runLuaCode({
+        luaCode: `vim.api.nvim_buf_set_lines(0, 0, 0, false, { "test subject", "", "body text", "", ${JSON.stringify(fixesLine)}, ${JSON.stringify(coauthorLine)} })`,
+      })
+      cy.typeIntoTerminal(":w{enter}")
+
+      waitForFormattingToHaveCompleted(nvim)
+
+      nvim.runExCommand({ command: `1,7yank` })
+      nvim.clipboard
+        .system()
+        .should(
+          "equal",
+          [
+            "test subject",
+            "",
+            "body text",
+            "",
+            fixesLine,
+            coauthorLine,
+            "",
+            "",
+          ].join("\n"),
+        )
+    })
+  })
+
+  it("preserves a trailer that appears in the middle of the message (e.g. from a squashed commit)", () => {
+    // When a commit is squashed from several smaller commits, each of which
+    // had its own trailer, the resulting message can contain trailer lines
+    // in the middle — not just at the end. Those middle trailers should
+    // also survive prettier's prose wrap so GitHub's keyword linking works.
+    const trailerLine =
+      "Fixes: https://example.com/very-long-organization-name/some-repo/issues/12345-long-slug"
+    assert(trailerLine.length > 72)
+
+    cy.visit("/")
+
+    cy.startNeovim({
+      filename: "fakegitrepo/file.txt",
+      NVIM_APPNAME: "nvim_formatting",
+    }).then((nvim) => {
+      cy.contains(fakeGitRepoFileText)
+      initializeGitRepositoryInDirectory()
+      nvim.runBlockingShellCommand({
+        command: `git add .`,
+        cwdRelative: "fakegitrepo",
+      })
+      cy.typeIntoTerminal("{rightarrow}")
+      cy.contains("main")
+
+      cy.typeIntoTerminal("C") // commit
+      nvim.waitForLuaCode({
+        luaAssertion: `return vim.api.nvim_buf_get_name(0) == vim.fn.expand('%:h') .. '/.git/COMMIT_EDITMSG'`,
+      })
+      cy.contains("# Please enter the commit message for your changes.")
+
+      nvim.runLuaCode({
+        luaCode: `vim.api.nvim_buf_set_lines(0, 0, 0, false, { "squash subject", "", "first sub-message body", "", ${JSON.stringify(trailerLine)}, "", "second sub-message body" })`,
+      })
+      cy.typeIntoTerminal(":w{enter}")
+
+      waitForFormattingToHaveCompleted(nvim)
+
+      nvim.runExCommand({ command: `1,8yank` })
+      nvim.clipboard
+        .system()
+        .should(
+          "equal",
+          [
+            "squash subject",
+            "",
+            "first sub-message body",
+            "",
+            trailerLine,
+            "",
+            "second sub-message body",
+            "",
+            "",
+          ].join("\n"),
+        )
+    })
+  })
 })

--- a/lua/tsugit/integrations/conform.lua
+++ b/lua/tsugit/integrations/conform.lua
@@ -6,6 +6,69 @@ local function is_long_mode()
   return #first_line > 72
 end
 
+local function is_trailer_line(line)
+  -- git-interpret-trailers(1): Token ": " value, Token is [A-Za-z0-9-]+
+  return line:match("^[A-Za-z][A-Za-z0-9%-]*:%s") ~= nil
+end
+
+local PRETTIER_IGNORE = "<!-- prettier-ignore -->"
+
+-- Insert a <!-- prettier-ignore --> comment above every paragraph that is
+-- entirely git trailers. Prettier treats the comment as a pragma and leaves
+-- the paragraph that follows it untouched, so long URLs in trailers don't
+-- get split across lines. After prettier runs, the markers are stripped
+-- back out, leaving the trailers intact in their original positions.
+--
+-- This handles trailer blocks anywhere in the message — including the
+-- middle, which happens when a commit is squashed from several smaller
+-- commits, each of which had its own trailer.
+---@param buf number
+local function shield_trailer_blocks_from_prettier(buf)
+  local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+  local new_lines = {}
+  local i = 1
+  local n = #lines
+  while i <= n do
+    if lines[i] == "" then
+      table.insert(new_lines, "")
+      i = i + 1
+    else
+      local para_start = i
+      while i <= n and lines[i] ~= "" do
+        i = i + 1
+      end
+      local para_end = i - 1
+
+      local all_trailers = true
+      for j = para_start, para_end do
+        if not is_trailer_line(lines[j]) then
+          all_trailers = false
+          break
+        end
+      end
+
+      if all_trailers then
+        table.insert(new_lines, PRETTIER_IGNORE)
+      end
+      for j = para_start, para_end do
+        table.insert(new_lines, lines[j])
+      end
+    end
+  end
+
+  vim.api.nvim_buf_set_lines(buf, 0, -1, true, new_lines)
+end
+
+---@param buf number
+local function unshield_trailer_blocks(buf)
+  -- Pattern is coupled to PRETTIER_IGNORE — update both if that constant
+  -- ever changes. Deletes into the black-hole register (d _) so we don't
+  -- clobber any register the user relied on.
+  vim.api.nvim_buf_call(buf, function()
+    vim.cmd([[silent! g/^<!-- prettier-ignore -->$/d _]])
+  end)
+end
+
 ---@param config tsugit.Config
 function M.setup_conform_prettierd_integration(config)
   local conform = require("conform")
@@ -118,6 +181,8 @@ M.format_comfy_mode = function(config, comment_char, buf)
     end
   end
 
+  shield_trailer_blocks_from_prettier(buf)
+
   if config.debug then
     require("tsugit.debug").add_debug_message(
       string.format(
@@ -132,6 +197,8 @@ M.format_comfy_mode = function(config, comment_char, buf)
     bufnr = buf,
     formatters = { "tsugit_gitcommit" },
   })
+
+  unshield_trailer_blocks(buf)
 
   -- put the commit instructions back
   if #instructions > 0 then
@@ -163,6 +230,8 @@ M.format_long_mode = function(config, comment_char, buf)
     end
   end
 
+  shield_trailer_blocks_from_prettier(buf)
+
   if config.debug then
     require("tsugit.debug").add_debug_message(
       string.format(
@@ -177,6 +246,8 @@ M.format_long_mode = function(config, comment_char, buf)
     bufnr = buf,
     formatters = { "tsugit_gitcommit" },
   })
+
+  unshield_trailer_blocks(buf)
 
   -- add the heading lines back to the beginning
   vim.api.nvim_buf_set_lines(buf, 0, 0, false, heading_lines)


### PR DESCRIPTION
# feat: ignore long git trailers in prettier prose wrap

In Github for instance, git trailers (https://git-scm.com/docs/git-interpret-trailers) like `Fixes: https://github.com/org/project/issue/1` may be specified to automatically link a commit with an issue https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue

Various things can then happen, for example automatically closing the issue when the commit is merged.

**Issue:**

When tsugit formats the commit message, it uses prettier with `--prose-wrap=always` to wrap long lines. But if a git trailer line is longer than the wrap width (e.g. because it contains a long URL), it gets put on the next line, breaking the git trailer.

**Solution:**

Don't format any git trailers at all. Leave them completely in tact, so they stay on a single line and GitHub's keyword linking keeps working.

---

# Pull request stack

- 👉🏻 **[#683](https://github.com/mikavilpas/tsugit.nvim/pull/683)** | feat: ignore long git trailers in prettier prose wrap 👈🏻