### PR TITLE
fix(release): use `version` specifier in commit message

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -28,7 +28,7 @@
       "@semantic-release/git",
       {
         "assets": ["lua/tsugit.lua"],
-        "message": "chore(release): ${nextRelease.version}"
+        "message": "version: ${nextRelease.version}"
       }
     ],
     "@semantic-release/github"


### PR DESCRIPTION
# fix(release): use `version` specifier in commit message

Also try it out by creating a new fake release after this (automatically).

---

# Pull request stack

- 👉🏻 **[#691](https://github.com/mikavilpas/tsugit.nvim/pull/691)** | fix(release): use `version` specifier in commit message 👈🏻