### PR TITLE
test: renovate keeps prettierd version up to date

### DIFF
--- a/integration-tests/test-environment/.config/nvim_formatting/prepare.lua
+++ b/integration-tests/test-environment/.config/nvim_formatting/prepare.lua
@@ -9,4 +9,7 @@
 vim.cmd("Lazy! sync")
 
 local command = require("mason.api.command")
-command.MasonInstall({ "prettierd" }, { version = "0.26.1" })
+command.MasonInstall({ "prettierd" }, {
+  -- renovate: datasource=github-releases depName=fsouza/prettierd
+  version = "0.26.1",
+})


### PR DESCRIPTION
# test: renovate keeps prettierd version up to date

---

# Pull request stack

- 👉🏻 **[#840](https://github.com/mikavilpas/tsugit.nvim/pull/840)** | test: renovate keeps prettierd version up to date 👈🏻