### PR TITLE
feat: support both prettierd and oxfmt for commit message formatting

### DIFF
--- a/assets/commit.oxfmtrc.json
+++ b/assets/commit.oxfmtrc.json
@@ -1,0 +1,4 @@
+{
+  "printWidth": 70,
+  "proseWrap": "always"
+}

--- a/integration-tests/MyTestDirectory.ts
+++ b/integration-tests/MyTestDirectory.ts
@@ -91,6 +91,10 @@ export const MyTestDirectorySchema = z.object({
           name: z.literal("map_key_to_start_lazygit_in_normal_screen_mode.lua"),
           type: z.literal("file"),
         }),
+        "use_oxfmt_for_formatting.lua": z.object({
+          name: z.literal("use_oxfmt_for_formatting.lua"),
+          type: z.literal("file"),
+        }),
         "use_prettierd_for_formatting.lua": z.object({
           name: z.literal("use_prettierd_for_formatting.lua"),
           type: z.literal("file"),
@@ -210,6 +214,7 @@ export const testDirectoryFiles = z.enum([
   ".config/nvim_formatting",
   ".config",
   "config-modifications/map_key_to_start_lazygit_in_normal_screen_mode.lua",
+  "config-modifications/use_oxfmt_for_formatting.lua",
   "config-modifications/use_prettierd_for_formatting.lua",
   "config-modifications",
   "dir with spaces/file1.txt",

--- a/integration-tests/cypress/e2e/formatting/oxfmt.cy.ts
+++ b/integration-tests/cypress/e2e/formatting/oxfmt.cy.ts
@@ -1,0 +1,409 @@
+import type {
+  MyStartNeovimServerArguments,
+  NeovimContext,
+} from "../../support/tui-sandbox.ts"
+import {
+  initializeGitRepositoryInDirectory,
+  waitForFormattingToHaveCompleted,
+} from "../test-utils.js"
+
+const fakeGitRepoFileText = "fake-git-repository-file-contents-71f64aabd056"
+
+const startNeovimWithOxfmt = (
+  args?: MyStartNeovimServerArguments,
+): Cypress.Chainable<NeovimContext> =>
+  cy.startNeovim({
+    ...args,
+    startupScriptModifications: ["use_oxfmt_for_formatting.lua"],
+  })
+
+describe("using oxfmt commit message formatting", () => {
+  it("can reformat a COMMIT_EDITMSG file with prettierd", () => {
+    cy.visit("/")
+
+    startNeovimWithOxfmt({
+      filename: "fakegitrepo/file.txt",
+      NVIM_APPNAME: "nvim_formatting",
+    }).then((nvim) => {
+      cy.contains(fakeGitRepoFileText)
+      initializeGitRepositoryInDirectory()
+      nvim.runBlockingShellCommand({
+        command: `git add .`,
+        cwdRelative: "fakegitrepo",
+      })
+      cy.typeIntoTerminal("{rightarrow}")
+
+      // wait until lazygit has initialized and the main branch name is visible
+      cy.contains("main")
+
+      cy.typeIntoTerminal("C") // commit
+      nvim.waitForLuaCode({
+        luaAssertion: `return vim.api.nvim_buf_get_name(0) == vim.fn.expand('%:h') .. '/.git/COMMIT_EDITMSG'`,
+      })
+      cy.contains("# Please enter the commit message for your changes.")
+
+      // add some unformatted text and save
+      nvim.runExCommand({ command: `normal! i  test` })
+      nvim.runExCommand({ command: `normal! o ` })
+      nvim.runExCommand({ command: `normal! o-  list` })
+      nvim.runExCommand({ command: `normal! o` })
+      nvim.runExCommand({
+        command: `normal! oLong line long line long line long line long long line long line line should wrap here`,
+      })
+      nvim.runExCommand({ command: `normal! gg` })
+      cy.typeIntoTerminal(":w{enter}")
+
+      waitForFormattingToHaveCompleted(nvim)
+      nvim.runExCommand({ command: `1,8yank` })
+      nvim.clipboard.system().should(
+        "equal",
+        [
+          // the subject line should be formatted when it's <72 chars
+          "test",
+          "",
+          "- list",
+          "",
+          "Long line long line long line long line long long line long line line",
+          "should wrap here",
+          "",
+          "# Please enter the commit message for your changes. Lines starting",
+          "",
+        ].join("\n"),
+      )
+    })
+  })
+
+  it("can reformat a COMMIT_EDITMSG file with a custom commentChar", () => {
+    // git allows customizing the comment character used in commit messages.
+    cy.visit("/")
+
+    startNeovimWithOxfmt({
+      filename: "fakegitrepo/file.txt",
+      NVIM_APPNAME: "nvim_formatting",
+    }).then((nvim) => {
+      cy.contains(fakeGitRepoFileText)
+      initializeGitRepositoryInDirectory()
+      nvim.runBlockingShellCommand({
+        command: `git add .`,
+        cwdRelative: "fakegitrepo",
+      })
+      // set the commentChar to a custom value
+      nvim.runBlockingShellCommand({
+        command: `git config core.commentChar ";"`,
+        cwdRelative: "fakegitrepo",
+      })
+      cy.typeIntoTerminal("{rightarrow}")
+
+      // wait until lazygit has initialized and the main branch name is visible
+      cy.contains("main")
+
+      cy.typeIntoTerminal("C") // commit
+      nvim.waitForLuaCode({
+        luaAssertion: `return vim.api.nvim_buf_get_name(0) == vim.fn.expand('%:h') .. '/.git/COMMIT_EDITMSG'`,
+      })
+      cy.contains("; Please enter the commit message for your changes.")
+
+      // add some unformatted text and save
+      nvim.runExCommand({ command: `normal! itest` })
+      nvim.runExCommand({ command: `normal! o ` })
+      nvim.runExCommand({ command: `normal! o-  list` })
+      nvim.runExCommand({ command: `normal! o` })
+      nvim.runExCommand({ command: `normal! gg` })
+      cy.typeIntoTerminal(":w{enter}")
+
+      waitForFormattingToHaveCompleted(nvim)
+
+      nvim.runExCommand({ command: `1,5yank` })
+      nvim.clipboard
+        .system()
+        .should(
+          "equal",
+          [
+            "test",
+            "",
+            "- list",
+            "",
+            "; Please enter the commit message for your changes. Lines starting",
+            "",
+          ].join("\n"),
+        )
+    })
+  })
+
+  const longSubject =
+    "chore: this is a very long subject line that should not be wrapped by the formatter"
+  assert(longSubject.length > 72)
+
+  it("formats in long mode when the commit subject is long", () => {
+    cy.visit("/")
+
+    startNeovimWithOxfmt({
+      filename: "fakegitrepo/file.txt",
+      NVIM_APPNAME: "nvim_formatting",
+    }).then((nvim) => {
+      cy.contains(fakeGitRepoFileText)
+      initializeGitRepositoryInDirectory()
+      nvim.runBlockingShellCommand({
+        command: `git add .`,
+        cwdRelative: "fakegitrepo",
+      })
+      cy.typeIntoTerminal("{rightarrow}")
+
+      // wait until lazygit has initialized and the main branch name is visible
+      cy.contains("main")
+
+      cy.typeIntoTerminal("C") // commit
+      nvim.waitForLuaCode({
+        luaAssertion: `return vim.api.nvim_buf_get_name(0) == vim.fn.expand('%:h') .. '/.git/COMMIT_EDITMSG'`,
+      })
+      cy.contains("# Please enter the commit message for your changes.")
+
+      // set the first line to contain longSubject
+      nvim.runLuaCode({
+        luaCode: `vim.api.nvim_buf_set_lines(0, 0, 1, false, { "${longSubject}" })`,
+      })
+
+      nvim.runExCommand({ command: `normal! o ` })
+      nvim.runExCommand({ command: `normal! o-  list` })
+      nvim.runExCommand({ command: `normal! o` })
+      nvim.runExCommand({ command: `normal! gg` })
+      cy.typeIntoTerminal(":w{enter}")
+
+      waitForFormattingToHaveCompleted(nvim)
+
+      nvim.runExCommand({ command: `1,3yank` })
+      nvim.clipboard
+        .system()
+        .should("equal", [longSubject, " ", "- list", ""].join("\n"))
+    })
+  })
+
+  it("preserves a long git trailer on a single line even when it exceeds the wrap width", () => {
+    // With --print-width=72 --prose-wrap=always, prettier would split a
+    // "Fixes: <long-url>" line at the space after "Fixes:", breaking
+    // GitHub's closing-keyword linking. The conform integration extracts
+    // the trailer block before prettier runs and re-appends it intact.
+    const trailerUrl =
+      "https://example.com/very-long-organization-name/some-repo/issues/12345-long-slug"
+    const trailerLine = `Fixes: ${trailerUrl}`
+    assert(trailerLine.length > 72)
+
+    cy.visit("/")
+
+    startNeovimWithOxfmt({
+      filename: "fakegitrepo/file.txt",
+      NVIM_APPNAME: "nvim_formatting",
+    }).then((nvim) => {
+      cy.contains(fakeGitRepoFileText)
+      initializeGitRepositoryInDirectory()
+      nvim.runBlockingShellCommand({
+        command: `git add .`,
+        cwdRelative: "fakegitrepo",
+      })
+      cy.typeIntoTerminal("{rightarrow}")
+      cy.contains("main")
+
+      cy.typeIntoTerminal("C") // commit
+      nvim.waitForLuaCode({
+        luaAssertion: `return vim.api.nvim_buf_get_name(0) == vim.fn.expand('%:h') .. '/.git/COMMIT_EDITMSG'`,
+      })
+      cy.contains("# Please enter the commit message for your changes.")
+
+      // Set up: subject, blank, body, blank, trailer — inserted via
+      // nvim_buf_set_lines so neovim's textwidth=72 auto-wrap doesn't split
+      // the long trailer line as we construct the test message. We want to
+      // test the prettier-wrap protection, not the typing-path wrap.
+      nvim.runLuaCode({
+        luaCode: `vim.api.nvim_buf_set_lines(0, 0, 0, false, { "test subject", "", "body text", "", ${JSON.stringify(trailerLine)} })`,
+      })
+      cy.typeIntoTerminal(":w{enter}")
+
+      waitForFormattingToHaveCompleted(nvim)
+
+      nvim.runExCommand({ command: `1,6yank` })
+      nvim.clipboard
+        .system()
+        .should(
+          "equal",
+          ["test subject", "", "body text", "", trailerLine, "", ""].join("\n"),
+        )
+    })
+  })
+
+  it("preserves a trailer block of multiple consecutive trailers", () => {
+    // Git trailer blocks can contain multiple lines (Fixes:, Signed-off-by:,
+    // Co-authored-by:, etc.). The whole last paragraph should be protected
+    // as a unit — every line must match the trailer pattern.
+    const fixesLine =
+      "Fixes: https://example.com/very-long-organization-name/some-repo/issues/12345-long-slug"
+    const coauthorLine =
+      "Co-authored-by: Alice Example <alice@very-long-organization-name.example.com>"
+    assert(fixesLine.length > 72)
+    assert(coauthorLine.length > 72)
+
+    cy.visit("/")
+
+    startNeovimWithOxfmt({
+      filename: "fakegitrepo/file.txt",
+      NVIM_APPNAME: "nvim_formatting",
+    }).then((nvim) => {
+      cy.contains(fakeGitRepoFileText)
+      initializeGitRepositoryInDirectory()
+      nvim.runBlockingShellCommand({
+        command: `git add .`,
+        cwdRelative: "fakegitrepo",
+      })
+      cy.typeIntoTerminal("{rightarrow}")
+      cy.contains("main")
+
+      cy.typeIntoTerminal("C") // commit
+      nvim.waitForLuaCode({
+        luaAssertion: `return vim.api.nvim_buf_get_name(0) == vim.fn.expand('%:h') .. '/.git/COMMIT_EDITMSG'`,
+      })
+      cy.contains("# Please enter the commit message for your changes.")
+
+      nvim.runLuaCode({
+        luaCode: `vim.api.nvim_buf_set_lines(0, 0, 0, false, { "test subject", "", "body text", "", ${JSON.stringify(fixesLine)}, ${JSON.stringify(coauthorLine)} })`,
+      })
+      cy.typeIntoTerminal(":w{enter}")
+
+      waitForFormattingToHaveCompleted(nvim)
+
+      nvim.runExCommand({ command: `1,7yank` })
+      nvim.clipboard
+        .system()
+        .should(
+          "equal",
+          [
+            "test subject",
+            "",
+            "body text",
+            "",
+            fixesLine,
+            coauthorLine,
+            "",
+            "",
+          ].join("\n"),
+        )
+    })
+  })
+
+  it("preserves a trailer that appears in the middle of the message (e.g. from a squashed commit)", () => {
+    // When a commit is squashed from several smaller commits, each of which
+    // had its own trailer, the resulting message can contain trailer lines
+    // in the middle — not just at the end. Those middle trailers should
+    // also survive prettier's prose wrap so GitHub's keyword linking works.
+    const trailerLine =
+      "Fixes: https://example.com/very-long-organization-name/some-repo/issues/12345-long-slug"
+    assert(trailerLine.length > 72)
+
+    cy.visit("/")
+
+    startNeovimWithOxfmt({
+      filename: "fakegitrepo/file.txt",
+      NVIM_APPNAME: "nvim_formatting",
+    }).then((nvim) => {
+      cy.contains(fakeGitRepoFileText)
+      initializeGitRepositoryInDirectory()
+      nvim.runBlockingShellCommand({
+        command: `git add .`,
+        cwdRelative: "fakegitrepo",
+      })
+      cy.typeIntoTerminal("{rightarrow}")
+      cy.contains("main")
+
+      cy.typeIntoTerminal("C") // commit
+      nvim.waitForLuaCode({
+        luaAssertion: `return vim.api.nvim_buf_get_name(0) == vim.fn.expand('%:h') .. '/.git/COMMIT_EDITMSG'`,
+      })
+      cy.contains("# Please enter the commit message for your changes.")
+
+      nvim.runLuaCode({
+        luaCode: `vim.api.nvim_buf_set_lines(0, 0, 0, false, { "squash subject", "", "first sub-message body", "", ${JSON.stringify(trailerLine)}, "", "second sub-message body" })`,
+      })
+
+      // assert the current line of the cursor
+      const expectedLine = "8" as const
+      nvim
+        .runExCommand({ command: "echo line('.')" })
+        .should("eql", { value: expectedLine })
+
+      cy.typeIntoTerminal(":w{enter}")
+
+      waitForFormattingToHaveCompleted(nvim)
+
+      nvim.runExCommand({ command: `1,8yank` })
+      nvim.clipboard
+        .system()
+        .should(
+          "equal",
+          [
+            "squash subject",
+            "",
+            "first sub-message body",
+            "",
+            trailerLine,
+            "",
+            "second sub-message body",
+            "",
+            "",
+          ].join("\n"),
+        )
+
+      // the cursor must be on the same line as before formatting
+      nvim
+        .runExCommand({ command: "echo line('.')" })
+        .should("eql", { value: expectedLine })
+    })
+  })
+
+  it("preserves a fenced code block whose contents include lines starting with the git comment char", () => {
+    // A fenced code block in the body can contain a line starting with
+    // the git comment char (e.g. a shell comment `# foo` in a ```sh
+    // block). A naive "first `#` line from the top is the start of git
+    // instructions" scan would mistake it for the start of the
+    // instructions and snip the buffer mid-fence — prettier then sees
+    // an unclosed fence and auto-closes it, and the `#` line ends up
+    // outside any fence, rendering as a markdown heading.
+    const commitLines = [
+      "subject",
+      "",
+      "```sh",
+      "# comment inside fenced code block",
+      "```",
+    ]
+
+    cy.visit("/")
+
+    startNeovimWithOxfmt({
+      filename: "fakegitrepo/file.txt",
+      NVIM_APPNAME: "nvim_formatting",
+    }).then((nvim) => {
+      cy.contains(fakeGitRepoFileText)
+      initializeGitRepositoryInDirectory()
+      nvim.runBlockingShellCommand({
+        command: `git add .`,
+        cwdRelative: "fakegitrepo",
+      })
+      cy.typeIntoTerminal("{rightarrow}")
+      cy.contains("main")
+
+      cy.typeIntoTerminal("C") // commit
+      nvim.waitForLuaCode({
+        luaAssertion: `return vim.api.nvim_buf_get_name(0) == vim.fn.expand('%:h') .. '/.git/COMMIT_EDITMSG'`,
+      })
+      cy.contains("# Please enter the commit message for your changes.")
+
+      const luaTable = commitLines.map((l) => JSON.stringify(l)).join(", ")
+      nvim.runLuaCode({
+        luaCode: `vim.api.nvim_buf_set_lines(0, 0, 0, false, { ${luaTable} })`,
+      })
+      cy.typeIntoTerminal(":w{enter}")
+
+      waitForFormattingToHaveCompleted(nvim)
+
+      nvim.runExCommand({ command: `1,${commitLines.length}yank` })
+      nvim.clipboard.system().should("equal", [...commitLines, ""].join("\n"))
+    })
+  })
+})

--- a/integration-tests/test-environment/.config/nvim_formatting/prepare.lua
+++ b/integration-tests/test-environment/.config/nvim_formatting/prepare.lua
@@ -13,3 +13,8 @@ command.MasonInstall({ "prettierd" }, {
   -- renovate: datasource=github-releases depName=fsouza/prettierd
   version = "0.27.0",
 })
+
+command.MasonInstall({ "oxfmt" }, {
+  -- renovate: datasource=npm depName=oxfmt
+  version = "0.57.0",
+})

--- a/integration-tests/test-environment/config-modifications/use_oxfmt_for_formatting.lua
+++ b/integration-tests/test-environment/config-modifications/use_oxfmt_for_formatting.lua
@@ -1,0 +1,7 @@
+require("tsugit").setup({
+  integrations = {
+    conform = {
+      formatter = "oxfmt",
+    },
+  },
+})

--- a/lua/tsugit.lua
+++ b/lua/tsugit.lua
@@ -11,7 +11,7 @@ local M = {}
 ---@field integrations? tsugit.IntegrationConfig
 
 ---@class(exact) tsugit.IntegrationConfig
----@field conform? { formatter: "prettierd" } | false # conform.nvim integration. If set to false, the integration is disabled.
+---@field conform? { formatter: "prettierd" | "oxfmt" } | false # conform.nvim integration. If set to false, the integration is disabled.
 
 ---@class(exact) tsugit.Keys
 ---@field toggle? string | false # toggle lazygit on/off without closing it
@@ -107,11 +107,9 @@ M.setup = function(config)
   if
     M.config.integrations
     and M.config.integrations.conform
-    and M.config.integrations.conform.formatter == "prettierd"
+    and M.config.integrations.conform.formatter
   then
-    require("tsugit.integrations.conform").setup_conform_prettierd_integration(
-      M.config
-    )
+    require("tsugit.integrations.conform").setup_conform_integration(M.config)
   end
 end
 

--- a/lua/tsugit/integrations/conform.lua
+++ b/lua/tsugit/integrations/conform.lua
@@ -126,27 +126,63 @@ local function extract_instructions(buf, comment_char)
 end
 
 ---@param config tsugit.Config
-function M.setup_conform_prettierd_integration(config)
+function M.setup_conform_integration(config)
   local conform = require("conform")
-  conform.setup({
-    formatters = {
-      tsugit_gitcommit = {
-        command = "prettierd",
-        args = {
-          -- provide the filename to the formatter so that it picks the
-          -- markdown language
-          "commit.md",
-          "--print-width=72",
-          "--prose-wrap=always",
+  if config.integrations.conform.formatter == "prettierd" then
+    conform.setup({
+      formatters = {
+        tsugit_gitcommit = {
+          command = "prettierd",
+          args = {
+            -- provide the filename to the formatter so that it picks the
+            -- markdown language
+            "commit.md",
+            "--print-width=72",
+            "--prose-wrap=always",
+          },
         },
       },
-    },
-  })
+    })
+    if config.debug then
+      require("tsugit.debug").add_debug_message(
+        "tsugit: Configured conform with prettierd for git commit messages"
+      )
+    end
+  elseif config.integrations.conform.formatter == "oxfmt" then
+    -- resolve the location of the oxfmt binary - adapted from
+    -- https://github.com/neovim/nvim-lspconfig/blob/master/lsp/oxfmt.lua
+    local cmd = "oxfmt" -- global default
+    local root_dir = vim.lsp.config.oxfmt or {}
+    if type(root_dir) == "string" then
+      local local_cmd = vim.fs.joinpath(root_dir, "node_modules/.bin", cmd)
+      if vim.fn.executable(local_cmd) == 1 then
+        cmd = local_cmd
+      end
+    end
 
-  if config.debug then
-    require("tsugit.debug").add_debug_message(
-      "tsugit: Configured conform with prettierd for git commit messages"
-    )
+    local this_file = vim.fs.normalize(debug.getinfo(1, "S").source:sub(2))
+    local plugin_root = vim.fn.fnamemodify(this_file, ":h:h:h:h")
+    local oxfmt_config_file =
+      vim.fs.joinpath(plugin_root, "assets", "commit.oxfmtrc.json")
+
+    conform.setup({
+      formatters = {
+        tsugit_gitcommit = {
+          command = cmd,
+          args = {
+            "--config",
+            oxfmt_config_file,
+            "--stdin-filepath",
+            "commit.md",
+          },
+        },
+      },
+    })
+    if config.debug then
+      require("tsugit.debug").add_debug_message(
+        "tsugit: Configured conform with oxfmt for git commit messages"
+      )
+    end
   end
 
   -- clear previous autocmds to avoid duplicates when called multiple times (e.g. in tests)

--- a/mise.toml
+++ b/mise.toml
@@ -4,7 +4,6 @@ lua = "5.1"
 "github:JohnnyMorganz/stylua" = "2.5.2"
 "github:rvben/rumdl" = "0.2.26"
 
-
 [tasks]
 test = "luarocks test --local"
 test-focus = "luarocks test --local -- --filter focus"


### PR DESCRIPTION
# feat: support both prettierd and oxfmt for commit message formatting

We try to use oxfmt from the node_modules/.bin directory if it's available. If not, we fallback to a global oxfmt binary, which the user is expected to have installed.

---

# Pull request stack

- 👉🏻 **[#843](https://github.com/mikavilpas/tsugit.nvim/pull/843)** | feat: support both prettierd and oxfmt for commit message formatting 👈🏻