### PR TITLE
ci: no need to install yq as it comes preinstalled

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,8 +74,6 @@ jobs:
               https://raw.githubusercontent.com/houseabsolute/ubi/master/bootstrap/bootstrap-ubi.sh |
               TARGET="$HOME/.local/bin" sh
 
-          ubi --project mikefarah/yq
-
           VERSION=$(yq '.tools."github:jesseduffield/lazygit"' mise.toml)
           ubi --project jesseduffield/lazygit --tag "v$VERSION"
         env:


### PR DESCRIPTION
# ci: no need to install yq as it comes preinstalled

https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md already contains `yq 4.53.3`

---

# Pull request stack

- 👉🏻 **[#848](https://github.com/mikavilpas/tsugit.nvim/pull/848)** | ci: no need to install yq as it comes preinstalled 👈🏻